### PR TITLE
Update sqlite-jdbc JAR link to Maven Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ from the template.
 
 1. In root directory with the pom.xml file run `mvn clean install`
 2. Take the resulting .jar file in the target folder and put it in the \dremio\jars folder in Dremio
-3. Take the SQLite JDBC driver from (https://bitbucket.org/xerial/sqlite-jdbc/downloads/) and put in in the \dremio\jars\3rdparty folder
+3. Take the SQLite JDBC driver from (https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/) and put in in the \dremio\jars\3rdparty folder
 4. Restart Dremio


### PR DESCRIPTION
- sqlite-jdbc repo is no longer available at link `https://bitbucket.org/xerial/sqlite-jdbc`
- Updated the link to get the JAR from Maven Repository