### PR TITLE
Sqlite plugin not building with Dremio 16.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.dremio.plugin</groupId>
-  <version>12.0.0-202012212145230282-d8947fd3</version>
+  <version>16.0.0-202105120132280783-b6a3f06a</version>
   <artifactId>dremio-sqlite-plugin</artifactId>
   <name>Dremio SQLite Community Connector</name>
 
   <properties>
-    <version.dremio>12.0.0-202012212145230282-d8947fd3</version.dremio>
+    <version.dremio>16.0.0-202105120132280783-b6a3f06a</version.dremio>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

Plugin failed to compile due to deprecated fields in Dremio 16. Also updated @SourceTypes to include "externalQuerySupported".

### Description

<!--- Details of what you changed -->

- Updated plugin version to match Dremio 16 version.
- Updated @SourceTypes to include "externalQuerySupported".
- Commented out deprecated "enableExternalQuery" field, left in with solution as legacy support.
- Added maxIdleConns and idleTimeSec for updated DataSources method.

Verified plugin compile with Dremio 16, and tested usage with a Sqlite database. External query was also verified.


### Additional Reviewers

<!-- Any additional reviewers -->

@jduo
