### PR TITLE
Update Dremio dependency to most recent OSS version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.dremio.plugin</groupId>
-  <version>16.0.0-202105120132280783-b6a3f06a</version>
+  <version>21.1.1-202204292111390812-57b1832f</version>
   <artifactId>dremio-sqlite-plugin</artifactId>
   <name>Dremio SQLite Community Connector</name>
 
   <properties>
-    <version.dremio>16.0.0-202105120132280783-b6a3f06a</version.dremio>
+    <version.dremio>21.1.1-202204292111390812-57b1832f</version.dremio>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
The current version of the Dremio dependency is 16.0.0 which is enterprise-only and not publicly available. Update to build against the most recent OSS Dremio version.