### PR TITLE
Cleanup up build warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (C) 2017-2018 Dremio Corporation
@@ -27,6 +27,7 @@
 
   <properties>
     <version.dremio>21.1.1-202204292111390812-57b1832f</version.dremio>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <dependencies>

--- a/src/main/java/com/dremio/exec/store/jdbc/conf/SqliteConf.java
+++ b/src/main/java/com/dremio/exec/store/jdbc/conf/SqliteConf.java
@@ -17,9 +17,7 @@ package com.dremio.exec.store.jdbc.conf;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.dremio.options.OptionManager;
-import com.dremio.security.CredentialsService;
-import org.hibernate.validator.constraints.NotBlank;
+import javax.validation.constraints.NotBlank;
 
 import com.dremio.exec.catalog.conf.DisplayMetadata;
 import com.dremio.exec.catalog.conf.NotMetadataImpacting;
@@ -29,6 +27,8 @@ import com.dremio.exec.store.jdbc.DataSources;
 import com.dremio.exec.store.jdbc.JdbcPluginConfig;
 import com.dremio.exec.store.jdbc.JdbcStoragePlugin;
 import com.dremio.exec.store.jdbc.dialect.arp.ArpDialect;
+import com.dremio.options.OptionManager;
+import com.dremio.security.CredentialsService;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.annotations.VisibleForTesting;
 


### PR DESCRIPTION
* Force use of UTF-8 as the file encoding
* Changed to the NotBlank annotation from the JDK