### PR TITLE
Use https for maven repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,11 +63,11 @@
   <repositories>
     <repository>
       <id>dremio-public</id>
-      <url>http://maven.dremio.com/public/</url>
+      <url>https://maven.dremio.com/public/</url>
     </repository>
     <repository>
       <id>dremio-free</id>
-      <url>http://maven.dremio.com/free/</url>
+      <url>https://maven.dremio.com/free/</url>
     </repository>    
   </repositories>
 </project>


### PR DESCRIPTION
For me, this fixes the following error:

```
Failed to execute goal on project dremio-sqlite-plugin: Could not resolve dependencies for project com.dremio.plugin:dremio-sqlite-plugin:jar:24.3.2-202401241821100032-d2d8a497: 
Failed to collect dependencies at com.dremio.community.plugins:dremio-ce-jdbc-plugin:jar:24.3.2-202401241821100032-d2d8a497: 
Failed to read artifact descriptor for com.dremio.community.plugins:dremio-ce-jdbc-plugin:jar:24.3.2-202401241821100032-d2d8a497: 
Could not transfer artifact com.dremio.community.plugins:dremio-ce-jdbc-plugin:pom:24.3.2-202401241821100032-d2d8a497 from/to maven-default-http-blocker (http://0.0.0.0/): 
Blocked mirror for repositories: [dremio-public (http://maven.dremio.com/public/, default, releases+snapshots), dremio-free (http://maven.dremio.com/free/, default, releases+snapshots)] -> [Help 1]
```